### PR TITLE
bug 1808969: azure terraform address prefixes 

### DIFF
--- a/azurerm/data_source_virtual_network_test.go
+++ b/azurerm/data_source_virtual_network_test.go
@@ -32,6 +32,30 @@ func TestAccDataSourceArmVirtualNetwork_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceArmVirtualNetwork_basic_addressPrefixes(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_virtual_network", "test")
+
+	name := fmt.Sprintf("acctestvnet-%d", data.RandomInteger)
+	config := testAccDataSourceArmVirtualNetwork_basic_addressPrefixes(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.SupportedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(data.ResourceName, "name", name),
+					resource.TestCheckResourceAttr(data.ResourceName, "location", azure.NormalizeLocation(data.Locations.Primary)),
+					resource.TestCheckResourceAttr(data.ResourceName, "dns_servers.0", "10.0.0.4"),
+					resource.TestCheckResourceAttr(data.ResourceName, "address_spaces.0", "10.0.0.0/16"),
+					resource.TestCheckResourceAttr(data.ResourceName, "subnets.0", "subnet1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceArmVirtualNetwork_peering(t *testing.T) {
 	dataSourceName := "data.azurerm_virtual_network.test"
 	ri := tf.AccRandTimeInt()
@@ -75,6 +99,33 @@ resource "azurerm_virtual_network" "test" {
   subnet {
     name           = "subnet1"
     address_prefix = "10.0.1.0/24"
+  }
+}
+
+data "azurerm_virtual_network" "test" {
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "${azurerm_virtual_network.test.name}"
+}
+`, rInt, location, rInt)
+}
+
+func testAccDataSourceArmVirtualNetwork_basic_addressPrefixes(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest%d-rg"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvnet-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  dns_servers         = ["10.0.0.4"]
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24", "10.0.2.0/24"]
   }
 }
 

--- a/azurerm/resource_arm_loadbalancer.go
+++ b/azurerm/resource_arm_loadbalancer.go
@@ -68,10 +68,9 @@ func resourceArmLoadBalancer() *schema.Resource {
 						},
 
 						"private_ip_address": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validate.IPv4AddressOrEmpty,
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
 						},
 
 						"private_ip_address_version": {

--- a/azurerm/resource_arm_virtual_network.go
+++ b/azurerm/resource_arm_virtual_network.go
@@ -91,10 +91,17 @@ func resourceArmVirtualNetwork() *schema.Resource {
 							ValidateFunc: validate.NoEmptyStrings,
 						},
 						"address_prefix": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validate.NoEmptyStrings,
+							Type:       schema.TypeString,
+							Optional:   true,
+							Deprecated: "Use the `address_prefixes` property instead.",
 						},
+
+						"address_prefixes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+
 						"security_group": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -289,7 +296,36 @@ func expandVirtualNetworkProperties(ctx context.Context, d *schema.ResourceData,
 			}
 			log.Printf("[INFO] Completed GET of Subnet props ")
 
-			prefix := subnet["address_prefix"].(string)
+			var prefixSet int = 0
+			properties := network.SubnetPropertiesFormat{}
+			if value, ok := subnet["address_prefixes"]; ok {
+				var addressPrefixes []string
+				for _, item := range value.([]interface{}) {
+					addressPrefixes = append(addressPrefixes, item.(string))
+				}
+				properties.AddressPrefixes = &addressPrefixes
+				if len(addressPrefixes) > 0 {
+					prefixSet += 1
+				}
+			}
+			if value, ok := subnet["address_prefix"]; ok {
+				addressPrefix := value.(string)
+				properties.AddressPrefix = &addressPrefix
+				if len(addressPrefix) > 0 {
+					prefixSet += 1
+				}
+			}
+			if properties.AddressPrefixes != nil && len(*properties.AddressPrefixes) == 1 {
+				properties.AddressPrefix = &(*properties.AddressPrefixes)[0]
+				properties.AddressPrefixes = nil
+			}
+			if prefixSet == 0 {
+				return nil, fmt.Errorf("[ERROR] either address_prefix or address_prefixes is required")
+			}
+			if prefixSet == 2 {
+				return nil, fmt.Errorf("[ERROR] either address_prefix or address_prefixes must be set, not both")
+			}
+
 			secGroup := subnet["security_group"].(string)
 
 			//set the props from config and leave the rest intact
@@ -298,7 +334,8 @@ func expandVirtualNetworkProperties(ctx context.Context, d *schema.ResourceData,
 				subnetObj.SubnetPropertiesFormat = &network.SubnetPropertiesFormat{}
 			}
 
-			subnetObj.SubnetPropertiesFormat.AddressPrefix = &prefix
+			subnetObj.SubnetPropertiesFormat.AddressPrefixes = properties.AddressPrefixes
+			subnetObj.SubnetPropertiesFormat.AddressPrefix = properties.AddressPrefix
 
 			if secGroup != "" {
 				subnetObj.SubnetPropertiesFormat.NetworkSecurityGroup = &network.SecurityGroup{
@@ -381,6 +418,14 @@ func flattenVirtualNetworkSubnets(input *[]network.Subnet) *schema.Set {
 			}
 
 			if props := subnet.SubnetPropertiesFormat; props != nil {
+				if prefixes := props.AddressPrefixes; prefixes != nil {
+					var addressPrefixes []interface{}
+					for _, prefix := range *prefixes {
+						addressPrefixes = append(addressPrefixes, prefix)
+					}
+					output["address_prefixes"] = addressPrefixes
+				}
+
 				if prefix := props.AddressPrefix; prefix != nil {
 					output["address_prefix"] = *prefix
 				}
@@ -416,8 +461,14 @@ func resourceAzureSubnetHash(v interface{}) int {
 
 	if m, ok := v.(map[string]interface{}); ok {
 		buf.WriteString(m["name"].(string))
-		buf.WriteString(m["address_prefix"].(string))
-
+		if v, ok := m["address_prefixes"]; ok {
+			for _, a := range v.([]interface{}) {
+				buf.WriteString(a.(string))
+			}
+		}
+		if v, ok := m["address_prefix"]; ok {
+			buf.WriteString(v.(string))
+		}
 		if v, ok := m["security_group"]; ok {
 			buf.WriteString(v.(string))
 		}

--- a/azurerm/resource_arm_virtual_network_test.go
+++ b/azurerm/resource_arm_virtual_network_test.go
@@ -38,6 +38,28 @@ func TestAccAzureRMVirtualNetwork_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualNetwork_basic_addressPrefixes(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
+	config := testAccAzureRMVirtualNetwork_basic_addressPrefixes(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMVirtualNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualNetworkExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "subnet.#", "1"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "subnet.1472110187.id"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMVirtualNetwork_requiresImport(t *testing.T) {
 	if !requireResourcesToBeImported {
 		t.Skip("Skipping since resources aren't required to be imported")
@@ -277,6 +299,27 @@ resource "azurerm_virtual_network" "test" {
   subnet {
     name           = "subnet1"
     address_prefix = "10.0.1.0/24"
+  }
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMVirtualNetwork_basic_addressPrefixes(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24", "10.0.2.0/24"]
   }
 }
 `, rInt, location, rInt)


### PR DESCRIPTION
When a subnet uses address_prefixes, address_prefix is null in the virtual network resource. Add address_prefixes to virtual network resource and allow null for address_prefix. Don't assume IPv4 for private_ip_address on load balancer resource.

https://bugzilla.redhat.com/show_bug.cgi?id=1808969