### PR TITLE
OCPBUGS-62653: Use storage account ID

### DIFF
--- a/internal/services/compute/shared_image_version_resource.go
+++ b/internal/services/compute/shared_image_version_resource.go
@@ -265,8 +265,8 @@ func resourceSharedImageVersionCreate(d *pluginsdk.ResourceData, meta interface{
 	if v, ok := d.GetOk("blob_uri"); ok {
 		version.Properties.StorageProfile.OsDiskImage = &galleryimageversions.GalleryDiskImage{
 			Source: &galleryimageversions.GalleryDiskImageSource{
-				Id:  pointer.To(d.Get("storage_account_id").(string)),
-				Uri: pointer.To(v.(string)),
+				StorageAccountId: pointer.To(d.Get("storage_account_id").(string)),
+				Uri:              pointer.To(v.(string)),
 			},
 		}
 	}
@@ -402,8 +402,17 @@ func resourceSharedImageVersionRead(d *pluginsdk.ResourceData, meta interface{})
 
 			osDiskSnapShotID := ""
 			storageAccountID := ""
-			if props.StorageProfile.OsDiskImage != nil && props.StorageProfile.OsDiskImage.Source != nil && props.StorageProfile.OsDiskImage.Source.Id != nil {
-				sourceID := *props.StorageProfile.OsDiskImage.Source.Id
+
+			if props.StorageProfile.OsDiskImage != nil && props.StorageProfile.OsDiskImage.Source != nil {
+				sourceID := ""
+				if props.StorageProfile.OsDiskImage.Source.Id != nil {
+					sourceID = *props.StorageProfile.OsDiskImage.Source.Id
+				}
+
+				if props.StorageProfile.OsDiskImage.Source.StorageAccountId != nil {
+					sourceID = *props.StorageProfile.OsDiskImage.Source.StorageAccountId
+				}
+
 				if blobURI == "" {
 					osDiskSnapShotID = sourceID
 				} else {


### PR DESCRIPTION
This fixes the upcoming Azure changes for blobs that now rely on the storage account ID to be set rather than the ID.