### PR TITLE
OCPBUGS-62653: OPENSHIFT: Use storage account ID

### DIFF
--- a/internal/services/compute/shared_image_version_resource.go
+++ b/internal/services/compute/shared_image_version_resource.go
@@ -266,10 +266,11 @@ func resourceSharedImageVersionCreateUpdate(d *pluginsdk.ResourceData, meta inte
 	}
 
 	if v, ok := d.GetOk("blob_uri"); ok {
+
 		version.GalleryImageVersionProperties.StorageProfile.OsDiskImage = &compute.GalleryOSDiskImage{
 			Source: &compute.GalleryDiskImageSource{
-				ID:  utils.String(d.Get("storage_account_id").(string)),
-				URI: utils.String(v.(string)),
+				StorageAccountID: utils.String(d.Get("storage_account_id").(string)),
+				URI:              utils.String(v.(string)),
 			},
 		}
 	}
@@ -350,7 +351,16 @@ func resourceSharedImageVersionRead(d *pluginsdk.ResourceData, meta interface{})
 			osDiskSnapShotID := ""
 			storageAccountID := ""
 			if profile.OsDiskImage != nil && profile.OsDiskImage.Source != nil && profile.OsDiskImage.Source.ID != nil {
-				sourceID := *profile.OsDiskImage.Source.ID
+
+				sourceID := ""
+				if profile.OsDiskImage.Source.ID != nil {
+					sourceID = *profile.OsDiskImage.Source.ID
+				}
+
+				if profile.OsDiskImage.Source.StorageAccountID != nil {
+					sourceID = *profile.OsDiskImage.Source.StorageAccountID
+				}
+
 				if blobURI == "" {
 					osDiskSnapShotID = sourceID
 				} else {


### PR DESCRIPTION
This fixes the upcoming Azure changes for blobs that now rely on the storage account ID to be set rather than the ID.

(cherry picked from commit df6748ecb632cea0d2d37d6ec09de57a9cf1fdb4)